### PR TITLE
Bump next-metrics version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "cron": "^1.0.9",
     "debounce": "^1.0.0",
     "isomorphic-fetch": "^2.1.1",
-    "next-metrics": "^1.16.3"
+    "next-metrics": "^3.1.2"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^2.0.4",


### PR DESCRIPTION
Because the previous version was pointing to a now non-existent graphite server
 🐿 v2.11.0